### PR TITLE
Adding legitimate, public rights value in fixture data

### DIFF
--- a/spec/fixtures/example.csv
+++ b/spec/fixtures/example.csv
@@ -1,3 +1,3 @@
 title,creator,keyword,rights,resource_type,visibility
-Great,Stephen Hawking,physics,Yes,ImageWork,open
+Great,Stephen Hawking,physics,http://creativecommons.org/publicdomain/zero/1.0/,ImageWork,open
 ,,,,,,

--- a/spec/fixtures/example_with_no_visibility.csv
+++ b/spec/fixtures/example_with_no_visibility.csv
@@ -1,3 +1,3 @@
 title,creator,keyword,rights,resource_type
-Great,Stephen Hawking,physics,Yes,ImageWork
+Great,Stephen Hawking,physics,http://creativecommons.org/publicdomain/zero/1.0/,ImageWork
 ,,,,,

--- a/spec/fixtures/raster_example.csv
+++ b/spec/fixtures/raster_example.csv
@@ -1,2 +1,2 @@
 title,creator,keyword,rights,resource_type,visibility,file_name
-Great Rasters,Stephen Hawking,physics,Yes,RasterWork,open,S_566_1914_clip.tif
+Great Rasters,Stephen Hawking,physics,http://creativecommons.org/publicdomain/zero/1.0/,RasterWork,open,S_566_1914_clip.tif

--- a/spec/importers/iris_mapper_spec.rb
+++ b/spec/importers/iris_mapper_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe IrisMapper do
     { "title" => "Great",
       "creator" => "Stephen Hawking",
       "keyword" => "physics",
-      "rights" => "Yes",
+      "rights" => "http://creativecommons.org/publicdomain/zero/1.0/",
       "resource_type" => "ImageWork" }
   end
   let(:hyrax_metadata) do
     { title: ["Great"],
       creator: ["Stephen Hawking"],
       keyword: ["physics"],
-      rights: ["Yes"],
+      rights: ["http://creativecommons.org/publicdomain/zero/1.0/"],
       resource_type: ["ImageWork"],
       visibility: nil,
       representative_file: nil }
@@ -37,8 +37,8 @@ RSpec.describe IrisMapper do
   end
 
   it "maps the required rights field" do
-    mapper.metadata = { "rights" => "Yes" }
-    expect(mapper.map_field(:rights)).to eq(["Yes"])
+    mapper.metadata = { "rights" => "http://creativecommons.org/publicdomain/zero/1.0/" }
+    expect(mapper.map_field(:rights)).to eq(["http://creativecommons.org/publicdomain/zero/1.0/"])
   end
 
   it "maps the required resource_type field" do


### PR DESCRIPTION
To make test imports records public and easily viewable in UI, for development purposes.