### PR TITLE
Specify rails-compatible version of pg gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'devise-guests', '~> 0.6'
 gem 'geo_works', github: 'samvera-labs/geo_works'
 gem 'hyrax', '1.0.5'
 gem 'loofah', '~> 2.2', '>= 2.2.1'
-gem 'pg'
+gem 'pg', '~> 0.18'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'rsolr', '>= 1.0'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,7 +533,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.0.5)
       ast (~> 2.4.0)
-    pg (1.0.0)
+    pg (0.21.0)
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.1)
@@ -853,7 +853,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   loofah (~> 2.2, >= 2.2.1)
-  pg
+  pg (~> 0.18)
   puma (~> 3.0)
   rails (~> 5.0.6)
   rsolr (>= 1.0)


### PR DESCRIPTION
Needed because of this bug: https://github.com/rails/rails/issues/31678

Connected to curationexperts/alexandria#70