### PR TITLE
Added a spec to test that geo_works jobs get queued during import. Story #18

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,13 +18,18 @@ Naming/FileName:
 
 Metrics/BlockLength:
   Exclude:
+    - "spec/importers/coverage_validator_spec.rb"
     - "spec/importers/iris_mapper_spec.rb"
     - "spec/importers/importer_spec.rb"
     - "app/controllers/catalog_controller.rb"
+    - "spec/rails_helper.rb"
 
 Metrics/LineLength:
   Exclude:
     - "app/importers/iris_mapper.rb"
 
 RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MessageSpies:
   Enabled: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -90,4 +90,27 @@ RSpec.configure do |config|
     Sipity::Role.find_or_create_by(name: 'managing')
     AdminSet.find_or_create_default_admin_set_id
   end
+
+  # Use this example group when you want to perform jobs inline during testing.
+  #
+  # Limit to specific job classes with:
+  # ActiveJob::Base.queue_adapter.filter = [IngestFileJob]
+  #
+  # Note: If you run CharacterizeJob, you'll want to
+  # stub out the part that calls fits since we don't
+  # have fits on the travis build:
+  # allow(Hydra::Works::CharacterizationService).to receive(:run)
+  #
+  config.before(perform_enqueued: true) do
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+  end
+
+  config.after(perform_enqueued: true) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+    ActiveJob::Base.queue_adapter = :test
+  end
 end


### PR DESCRIPTION
Note:  I removed the `:perform_enqueued` and `ActiveJob::Base.queue_adapter.filter = [IngestFileJob]` from some specs because `:perform_enqueued` wasn't defined before this, so those jobs weren't actually running.  Those specs don't need to run the background jobs, so I turned them off to make specs run faster.