### PR TITLE
Fix GeoServer publishing, story #50

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'tmp/**/*'
     - '**/*.gemspec' # these would normally be inherited from bixby
     - 'config/**/*'
+    - 'app/models/geo_server/coverage.rb'
 
 Layout/MultilineMethodCallIndentation:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/samvera-labs/geo_works.git
-  revision: 95b6f726a4111e98f09f4cb257ff9d648564f0ee
+  revision: df1eff35fd01469a623fafeb9d71b44fd6160ca8
   specs:
     geo_works (0.2.0)
       hyrax (>= 1.0.1, < 2.0)

--- a/app/models/geo_server/coverage.rb
+++ b/app/models/geo_server/coverage.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module GeoServer
+  class Coverage < RGeoServer::Coverage
+
+    # This method overrides the method from rgeoserver
+    # to remove the nativeName from the XML.
+    # This is the problem we had:
+    # https://github.com/curationexperts/iris/issues/50
+    # and here:
+    # https://gis.stackexchange.com/questions/133115/geoserver-rest-api-bug-the-specified-coveragename-is-not-supported
+    def message
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.coverage {
+          xml.name @name
+          xml.title @title if title_changed? || new?
+          xml.abstract @abstract if abstract_changed? || new?
+          xml.enabled @enabled
+          xml.metadataLinks {
+            @metadata_links.each do |m|
+              raise ArgumentError, "Malformed metadata_links" unless m.is_a? Hash
+              xml.metadataLink {
+                xml.type_ to_mimetype(m['metadataType'])
+                xml.metadataType m['metadataType']
+                xml.content m['content']
+              }
+            end
+          } unless @metadata_links.empty?
+          xml.keywords {
+            @keywords.each do |k|
+              xml.keyword RGeoServer::Metadata::to_keyword(k)
+            end
+          } if @keywords and new? or keywords_changed?
+
+        }
+      end
+      @message = builder.doc.to_xml
+    end
+
+  end
+end

--- a/config/initializers/geo_works_overrides.rb
+++ b/config/initializers/geo_works_overrides.rb
@@ -9,3 +9,6 @@ GeoWorks::Discovery::DocumentBuilder.services = [
   GeoWorks::Discovery::DocumentBuilder::LayerInfoBuilder,
   GeoWorks::Discovery::DocumentBuilder::SlugBuilder
 ]
+
+# Use our own Coverage model for talking to GeoServer.
+GeoWorks::Delivery::Geoserver.coverage_class = ::GeoServer::Coverage


### PR DESCRIPTION
This is a work-around to fix the problem described in story #50, where
geotiff files weren't being properly published in GeoServer, so the
raster image didn't appear in the geoblacklight front-end.

I overrode a method from `rgeoserver` gem to remove an element from the
XML document that was causing an error when POSTing to GeoServer.

I also added a rubocop exclusion for the new file because rubocop had a
lot of complaints.  Since I'm overriding a method from a gem, I wanted
the overridden code to be as identical as possible to the original code,
to make it easy for developers to compare the changes.